### PR TITLE
feat(auth): Add AuthController with Swagger documentation for register and login

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  @Post('register')
+  @ApiOperation({ summary: 'Register a new user' })
+  @ApiResponse({ status: 201, description: 'User registered successfully' })
+  register(@Body() registerDto: RegisterDto) {
+    // Registration logic here
+    return { message: 'User registered (mock)' };
+  }
+
+  @Post('login')
+  @ApiOperation({ summary: 'Login and get JWT' })
+  @ApiResponse({ status: 200, description: 'JWT token returned' })
+  login(@Body() loginDto: LoginDto) {
+    // Login logic here
+    return { access_token: 'mock-jwt-token' };
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,7 @@
 import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
 
-@Module({})
+@Module({
+	controllers: [AuthController],
+})
 export class AuthModule {}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LoginDto {
+  @ApiProperty({ example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ example: 'password123' })
+  password: string;
+}

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RegisterDto {
+  @ApiProperty({ example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ example: 'password123' })
+  password: string;
+
+  @ApiProperty({ example: 'John Doe' })
+  name: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ async function bootstrap() {
     .setTitle('Task manager API')
     .setDescription('API documnetation for Task manager')
     .setVersion('1.0')
+    .addBearerAuth() // 👈 adds JWT auth option in Swagger UI
     .build();
 
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
Introduces a new AuthController with /auth/register and /auth/login endpoints.
Adds DTOs for registration and login, with Swagger decorators for API documentation.
Registers the controller in [AuthModule](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Endpoints are now visible and testable in Swagger UI (/apidocs).
No breaking changes to existing functionality.